### PR TITLE
Resolve error on empty multiple-contact field

### DIFF
--- a/CRM/Core/BAO/CustomField.php
+++ b/CRM/Core/BAO/CustomField.php
@@ -1070,12 +1070,10 @@ class CRM_Core_BAO_CustomField extends CRM_Core_DAO_CustomField {
       case 'Radio':
       case 'CheckBox':
         if ($field['data_type'] == 'ContactReference' && (is_array($value) || is_numeric($value))) {
-          if (empty($value))
-          {
+          if (empty($value)) {
             $display = '';
           }
-          else
-          {
+          else {
             $displayNames = [];
             foreach ((array) $value as $contactId) {
               $displayNames[] = CRM_Core_DAO::getFieldValue('CRM_Contact_DAO_Contact', $contactId, 'display_name');

--- a/CRM/Core/BAO/CustomField.php
+++ b/CRM/Core/BAO/CustomField.php
@@ -1069,12 +1069,19 @@ class CRM_Core_BAO_CustomField extends CRM_Core_DAO_CustomField {
       case 'Autocomplete-Select':
       case 'Radio':
       case 'CheckBox':
-        if ($field['data_type'] == 'ContactReference' && (is_array($value) || is_numeric($value)) && !empty($value)) {
-          $displayNames = [];
-          foreach ((array) $value as $contactId) {
-            $displayNames[] = CRM_Core_DAO::getFieldValue('CRM_Contact_DAO_Contact', $contactId, 'display_name');
+        if ($field['data_type'] == 'ContactReference' && (is_array($value) || is_numeric($value))) {
+          if (empty($value))
+          {
+            $display = '';
           }
-          $display = implode(', ', $displayNames);
+          else
+          {
+            $displayNames = [];
+            foreach ((array) $value as $contactId) {
+              $displayNames[] = CRM_Core_DAO::getFieldValue('CRM_Contact_DAO_Contact', $contactId, 'display_name');
+            }
+            $display = implode(', ', $displayNames);
+          }
         }
         elseif ($field['data_type'] == 'ContactReference') {
           $display = $value;

--- a/CRM/Core/BAO/CustomField.php
+++ b/CRM/Core/BAO/CustomField.php
@@ -1069,7 +1069,7 @@ class CRM_Core_BAO_CustomField extends CRM_Core_DAO_CustomField {
       case 'Autocomplete-Select':
       case 'Radio':
       case 'CheckBox':
-        if ($field['data_type'] == 'ContactReference' && (is_array($value) || is_numeric($value))) {
+        if ($field['data_type'] == 'ContactReference' && (is_array($value) || is_numeric($value)) && !empty($value)) {
           $displayNames = [];
           foreach ((array) $value as $contactId) {
             $displayNames[] = CRM_Core_DAO::getFieldValue('CRM_Contact_DAO_Contact', $contactId, 'display_name');


### PR DESCRIPTION
This change removes a potential "getFieldValue failed" error that can be thrown if an empty scalar value occurs in a multiple-contact reference custom field.

See https://lab.civicrm.org/dev/core/-/issues/2939
